### PR TITLE
ACP input: @ file picker and clipboard image paste

### DIFF
--- a/crates/editor-sdl/src/shell/acp.rs
+++ b/crates/editor-sdl/src/shell/acp.rs
@@ -10,22 +10,25 @@ use std::{
 
 use agent_client_protocol::{Agent, Client, ClientSideConnection};
 use agent_client_protocol::{
-    AuthCapabilities, AvailableCommand, ClientCapabilities, ContentBlock, CreateTerminalRequest,
-    CreateTerminalResponse, Error, FileSystemCapabilities, Implementation, InitializeRequest,
+    AuthCapabilities, AvailableCommand, BlobResourceContents, ClientCapabilities, ContentBlock,
+    CreateTerminalRequest, CreateTerminalResponse, EmbeddedResource, EmbeddedResourceResource,
+    Error, FileSystemCapabilities, Implementation, InitializeRequest,
     KillTerminalRequest, KillTerminalResponse, ListSessionsRequest, LoadSessionRequest, Meta,
     ModelId, ModelInfo, NewSessionRequest, PermissionOption, PermissionOptionId,
     PermissionOptionKind, Plan, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
     ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome,
     SessionConfigId, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOption, SessionConfigSelectOptions, SessionConfigValueId, SessionInfo,
     SessionInfoUpdate, SessionMode, SessionModeId, SessionModeState, SessionModelState,
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
     SetSessionModelRequest, StopReason, TerminalExitStatus, TerminalId, TerminalOutputRequest,
-    TerminalOutputResponse, ToolCall, ToolCallUpdate, WaitForTerminalExitRequest,
-    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
+    TerminalOutputResponse, TextContent, TextResourceContents, ToolCall, ToolCallUpdate,
+    WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
+    WriteTextFileResponse,
 };
 use async_trait::async_trait;
+use base64::Engine as _;
 use editor_jobs::{ProcessSupervisionMode, supervised_command_if_resolved};
 use editor_picker::PickerResultOrder;
 use editor_plugin_api::AcpClient as AcpClientConfig;
@@ -1027,8 +1030,9 @@ fn active_acp_client(runtime: &EditorRuntime) -> Result<AcpClientConfig, String>
 pub(super) fn submit_acp_prompt(
     runtime: &mut EditorRuntime,
     buffer_id: BufferId,
-    prompt: &str,
+    _prompt: &str,
     text: &str,
+    pending_images: Vec<AcpPendingImage>,
 ) -> Result<(), String> {
     let manager = runtime
         .services()
@@ -1041,9 +1045,14 @@ pub(super) fn submit_acp_prompt(
             .map_err(|_| "acp manager lock was poisoned".to_owned())?;
         manager.session_for_buffer(buffer_id)
     };
+    let workspace_root = active_workspace_root(runtime)?;
+    let prompt_blocks =
+        build_acp_prompt_blocks(text, &pending_images, workspace_root.as_deref())?;
+    let display_blocks = prompt_blocks.clone();
     let Some(session_id) = session_id else {
         let follow = {
             let buffer = shell_buffer_mut(runtime, buffer_id)?;
+            let _ = buffer.acp_push_user_message(display_blocks);
             let follow = buffer.acp_push_system_message("ACP session is not connected.");
             buffer.clear_input();
             follow
@@ -1054,7 +1063,7 @@ pub(super) fn submit_acp_prompt(
     };
     let follow = {
         let buffer = shell_buffer_mut(runtime, buffer_id)?;
-        let follow = buffer.acp_push_user_prompt(format!("{prompt}{text}"));
+        let follow = buffer.acp_push_user_message(display_blocks);
         buffer.clear_input();
         follow
     };
@@ -1063,7 +1072,7 @@ pub(super) fn submit_acp_prompt(
     let mut manager = manager
         .lock()
         .map_err(|_| "acp manager lock was poisoned".to_owned())?;
-    manager.prompt(session_id, text.to_owned())
+    manager.prompt(session_id, prompt_blocks)
 }
 
 pub(super) fn acp_complete_slash(runtime: &mut EditorRuntime) -> Result<(), String> {
@@ -1154,6 +1163,226 @@ pub(super) fn acp_insert_slash_command(
     Ok(())
 }
 
+pub(super) fn maybe_open_file_completion(
+    runtime: &mut EditorRuntime,
+    buffer_id: BufferId,
+) -> Result<(), String> {
+    let Some(text) = ({
+        let buffer = shell_buffer(runtime, buffer_id)?;
+        if !matches!(
+            &buffer.kind,
+            BufferKind::Plugin(plugin_kind) if plugin_kind == ACP_BUFFER_KIND
+        ) {
+            return Ok(());
+        }
+        buffer.input_field().map(|input| input.text().to_owned())
+    }) else {
+        return Ok(());
+    };
+    let picker_kind = shell_ui(runtime)?.picker_kind();
+    let file_picker_active = matches!(
+        picker_kind,
+        Some(PickerKind::AcpFile {
+            buffer_id: picker_buffer_id,
+        }) if picker_buffer_id == buffer_id
+    );
+    let Some(trimmed) = acp_file_completion_query(&text) else {
+        if file_picker_active {
+            shell_ui_mut(runtime)?.close_picker();
+        }
+        return Ok(());
+    };
+    if shell_ui(runtime)?.picker_visible() {
+        if file_picker_active {
+            shell_ui_mut(runtime)?.close_picker();
+        } else {
+            return Ok(());
+        }
+    }
+    open_file_reference_picker(
+        runtime,
+        buffer_id,
+        CompletionTrigger::Auto(trimmed.to_owned()),
+    )
+}
+
+pub(super) fn acp_insert_file_reference(
+    runtime: &mut EditorRuntime,
+    buffer_id: BufferId,
+    path: &str,
+) -> Result<(), String> {
+    let buffer = shell_buffer_mut(runtime, buffer_id)?;
+    let Some(input) = buffer.input_field_mut() else {
+        return Err("ACP buffer has no input field".to_owned());
+    };
+    let existing = input.text().to_owned();
+    let Some(at_index) = existing.rfind('@') else {
+        let next = if existing.is_empty() {
+            format!("@{path} ")
+        } else if existing.ends_with(' ') {
+            format!("{existing}@{path} ")
+        } else {
+            format!("{existing} @{path} ")
+        };
+        input.set_text(&next);
+        refresh_acp_input_hint(runtime, buffer_id)?;
+        return Ok(());
+    };
+    let prefix = &existing[..=at_index];
+    let next = format!("{prefix}{path} ");
+    input.set_text(&next);
+    refresh_acp_input_hint(runtime, buffer_id)?;
+    Ok(())
+}
+
+fn acp_file_completion_query(text: &str) -> Option<&str> {
+    let at_index = text.rfind('@')?;
+    let after = &text[at_index + 1..];
+    if after.contains('\n') || after.contains(' ') {
+        return None;
+    }
+    Some(after)
+}
+
+fn open_file_reference_picker(
+    runtime: &mut EditorRuntime,
+    buffer_id: BufferId,
+    trigger: CompletionTrigger,
+) -> Result<(), String> {
+    if shell_ui(runtime)?.picker_visible() {
+        return Ok(());
+    }
+    let workspace_root = active_workspace_root(runtime)?;
+    let Some(root) = workspace_root else {
+        return Ok(());
+    };
+    let files = list_repository_files(&root).unwrap_or_default();
+    if files.is_empty() {
+        return Ok(());
+    }
+    let entries = files
+        .into_iter()
+        .map(|relative_path| {
+            let display = relative_path.display().to_string();
+            let absolute = root.join(&relative_path);
+            PickerEntry {
+                item: PickerItem::new(
+                    display.clone(),
+                    display.clone(),
+                    String::new(),
+                    None::<String>,
+                )
+                .with_search_text(display.clone())
+                .with_fringe(editor_icons::seti_file_icon(&absolute)),
+                action: PickerAction::AcpInsertFileReference {
+                    buffer_id,
+                    path: display,
+                },
+                quickfix: None,
+            }
+        })
+        .collect();
+    let mut picker = PickerOverlay::from_entries("ACP Files", entries);
+    match trigger {
+        CompletionTrigger::Auto(query) => {
+            if !query.is_empty() {
+                picker.append_query(&query);
+            }
+        }
+        CompletionTrigger::Manual => {}
+    }
+    shell_ui_mut(runtime)?.set_picker(picker.with_kind(PickerKind::AcpFile { buffer_id }));
+    Ok(())
+}
+
+fn parse_at_mentions(text: &str) -> Vec<String> {
+    let mut mentions = Vec::new();
+    let mut search_from = 0usize;
+    while let Some(at_index) = text[search_from..].find('@') {
+        let start = search_from + at_index + 1;
+        let rest = &text[start..];
+        let end = rest
+            .find(|character: char| character.is_whitespace())
+            .unwrap_or(rest.len());
+        let mention = rest[..end].trim();
+        if !mention.is_empty() && !mentions.iter().any(|existing| existing == mention) {
+            mentions.push(mention.to_owned());
+        }
+        search_from = start.saturating_add(end.max(1));
+    }
+    mentions
+}
+
+fn acp_file_uri(root: &Path, relative: &str) -> String {
+    let path = root.join(relative);
+    format!("file://{}", path.display())
+}
+
+fn acp_guess_text_mime_type(path: &str) -> Option<String> {
+    match path.rsplit('.').next()?.to_ascii_lowercase().as_str() {
+        "rs" => Some("text/x-rust".to_owned()),
+        "md" => Some("text/markdown".to_owned()),
+        "json" => Some("application/json".to_owned()),
+        "yaml" | "yml" => Some("application/yaml".to_owned()),
+        "toml" => Some("application/toml".to_owned()),
+        "html" => Some("text/html".to_owned()),
+        "css" => Some("text/css".to_owned()),
+        "js" => Some("text/javascript".to_owned()),
+        "ts" => Some("text/typescript".to_owned()),
+        "py" => Some("text/x-python".to_owned()),
+        "sh" => Some("text/x-shellscript".to_owned()),
+        _ => Some("text/plain".to_owned()),
+    }
+}
+
+fn acp_embed_file_reference(root: &Path, relative: &str) -> ContentBlock {
+    let path = root.join(relative);
+    let uri = acp_file_uri(root, relative);
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        let mut resource = TextResourceContents::new(content, uri);
+        if let Some(mime_type) = acp_guess_text_mime_type(relative) {
+            resource = resource.mime_type(mime_type);
+        }
+        return ContentBlock::Resource(EmbeddedResource::new(
+            EmbeddedResourceResource::TextResourceContents(resource),
+        ));
+    }
+    if let Ok(bytes) = std::fs::read(&path) {
+        let blob = base64::engine::general_purpose::STANDARD.encode(bytes);
+        let mut resource = BlobResourceContents::new(blob, uri);
+        if let Some(mime_type) = acp_guess_text_mime_type(relative) {
+            resource = resource.mime_type(mime_type);
+        }
+        return ContentBlock::Resource(EmbeddedResource::new(
+            EmbeddedResourceResource::BlobResourceContents(resource),
+        ));
+    }
+    ContentBlock::ResourceLink(ResourceLink::new(relative, acp_file_uri(root, relative)))
+}
+
+fn build_acp_prompt_blocks(
+    text: &str,
+    pending_images: &[AcpPendingImage],
+    workspace_root: Option<&Path>,
+) -> Result<Vec<ContentBlock>, String> {
+    let mut blocks = Vec::new();
+    if !text.trim().is_empty() {
+        blocks.push(ContentBlock::Text(TextContent::new(text)));
+    }
+    if let Some(root) = workspace_root {
+        for mention in parse_at_mentions(text) {
+            blocks.push(acp_embed_file_reference(root, &mention));
+        }
+    }
+    for image in pending_images {
+        blocks.push(image.to_content_block());
+    }
+    if blocks.is_empty() {
+        return Err("ACP prompt is empty".to_owned());
+    }
+    Ok(blocks)
+}
+
 fn format_acp_mode_label(mode_id: &SessionModeId) -> String {
     let raw = mode_id.to_string();
     if let Some((_, suffix)) = raw.rsplit_once('#')
@@ -1200,6 +1429,7 @@ fn build_acp_input_hint(
     mode_id: Option<&SessionModeId>,
     model_id: Option<&ModelId>,
     command_hint: Option<&str>,
+    pending_images: usize,
 ) -> Option<String> {
     let mut segments = Vec::new();
     if let Some(mode_id) = mode_id {
@@ -1210,6 +1440,14 @@ fn build_acp_input_hint(
     }
     if let Some(command_hint) = command_hint.filter(|hint| !hint.trim().is_empty()) {
         segments.push(command_hint.to_owned());
+    }
+    if pending_images > 0 {
+        let label = if pending_images == 1 {
+            "1 image attached".to_owned()
+        } else {
+            format!("{pending_images} images attached")
+        };
+        segments.push(label);
     }
     if mode_id.is_some() {
         segments.push("shift+tab switch mode".to_owned());
@@ -1233,7 +1471,16 @@ fn update_acp_input_hint(
         .and_then(|buffer| buffer.input_field().map(|input| input.text().to_owned()))
         .unwrap_or_default();
     let command_hint = active_command_input_hint(available_commands, &input_text);
-    let hint = build_acp_input_hint(mode_id, model_id, command_hint.as_deref());
+    let pending_images = shell_buffer(runtime, buffer_id)
+        .ok()
+        .map(|buffer| buffer.acp_pending_image_count())
+        .unwrap_or(0);
+    let hint = build_acp_input_hint(
+        mode_id,
+        model_id,
+        command_hint.as_deref(),
+        pending_images,
+    );
     if let Ok(buffer) = shell_buffer_mut(runtime, buffer_id)
         && let Some(footer) = buffer.acp_footer_pane_mut()
     {
@@ -2176,9 +2423,10 @@ impl AcpManager {
     fn prompt(
         &mut self,
         session_id: agent_client_protocol::SessionId,
-        prompt: String,
+        prompt: Vec<ContentBlock>,
     ) -> Result<(), String> {
-        self.runtime.send(AcpCommand::Prompt { session_id, prompt })
+        self.runtime
+            .send(AcpCommand::Prompt { session_id, prompt })
     }
 
     fn list_sessions(
@@ -3355,7 +3603,7 @@ enum AcpCommand {
     },
     Prompt {
         session_id: agent_client_protocol::SessionId,
-        prompt: String,
+        prompt: Vec<ContentBlock>,
     },
     ListSessions {
         session_id: agent_client_protocol::SessionId,
@@ -3672,7 +3920,7 @@ async fn connect_acp_client(
 async fn send_acp_prompt(
     state: Rc<RefCell<AcpRuntimeState>>,
     session_id: agent_client_protocol::SessionId,
-    prompt: String,
+    prompt: Vec<ContentBlock>,
 ) -> Result<(), String> {
     let connection = {
         state
@@ -3682,10 +3930,7 @@ async fn send_acp_prompt(
             .map(|session| session.connection.clone())
     }
     .ok_or_else(|| "ACP session is not connected".to_owned())?;
-    let request = agent_client_protocol::PromptRequest::new(
-        session_id.clone(),
-        vec![ContentBlock::from(prompt)],
-    );
+    let request = agent_client_protocol::PromptRequest::new(session_id.clone(), prompt);
     let response = connection
         .prompt(request)
         .await
@@ -5452,5 +5697,52 @@ mod tests {
         assert!(acp_slash_completion_query("/fix\nmore").is_none());
         assert!(acp_slash_completion_query("i have this code //").is_none());
         assert!(acp_slash_completion_query(" //").is_none());
+    }
+
+    #[test]
+    fn acp_file_completion_query_detects_trailing_at_mention_token() {
+        assert_eq!(acp_file_completion_query("@"), Some(""));
+        assert_eq!(acp_file_completion_query("look at @src"), Some("src"));
+        assert_eq!(
+            acp_file_completion_query("compare @crates/editor-sdl/src/lib.rs"),
+            Some("crates/editor-sdl/src/lib.rs")
+        );
+        assert!(acp_file_completion_query("look at @src/foo and bar").is_none());
+        assert!(acp_file_completion_query("@src\nmore").is_none());
+    }
+
+    #[test]
+    fn parse_at_mentions_collects_unique_paths() {
+        assert_eq!(
+            parse_at_mentions("review @src/lib.rs and @src/main.rs"),
+            vec!["src/lib.rs".to_owned(), "src/main.rs".to_owned()]
+        );
+        assert_eq!(parse_at_mentions("no mentions here"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn build_acp_prompt_blocks_embeds_text_files_and_images() {
+        let root = std::env::temp_dir().join(format!("volt-acp-prompt-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp dir");
+        std::fs::write(root.join("note.txt"), "hello").expect("write note");
+
+        let image = AcpPendingImage {
+            mime_type: "image/png".to_owned(),
+            data_base64: "aGVsbG8=".to_owned(),
+        };
+        let blocks = build_acp_prompt_blocks(
+            "please review @note.txt",
+            &[image],
+            Some(root.as_path()),
+        )
+        .expect("prompt blocks");
+
+        assert_eq!(blocks.len(), 3);
+        assert!(matches!(blocks[0], ContentBlock::Text(_)));
+        assert!(matches!(blocks[1], ContentBlock::Resource(_)));
+        assert!(matches!(blocks[2], ContentBlock::Image(_)));
+
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/editor-sdl/src/shell/clipboard.rs
+++ b/crates/editor-sdl/src/shell/clipboard.rs
@@ -1,5 +1,7 @@
 use super::*;
 use std::cell::RefCell;
+use std::ffi::CString;
+use std::path::Path;
 
 struct ClipboardContext {
     video: sdl3::VideoSubsystem,
@@ -53,6 +55,74 @@ pub(super) fn read_system_clipboard() -> Option<String> {
     .filter(|text| !text.is_empty())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ClipboardImage {
+    pub mime_type: String,
+    pub data: Vec<u8>,
+}
+
+const CLIPBOARD_IMAGE_MIME_TYPES: &[&str] = &["image/png", "image/jpeg", "image/webp", "image/gif"];
+
+pub(super) fn read_system_clipboard_image() -> Option<ClipboardImage> {
+    CLIPBOARD_CONTEXT.with(|context| {
+        if context.borrow().is_none() {
+            return None;
+        }
+        for mime_type in CLIPBOARD_IMAGE_MIME_TYPES {
+            let mime = CString::new(*mime_type).ok()?;
+            let image = unsafe {
+                if !sdl3::sys::clipboard::SDL_HasClipboardData(mime.as_ptr()) {
+                    continue;
+                }
+                let mut size = 0usize;
+                let ptr = sdl3::sys::clipboard::SDL_GetClipboardData(mime.as_ptr(), &mut size);
+                if ptr.is_null() || size == 0 {
+                    continue;
+                }
+                let data = std::slice::from_raw_parts(ptr as *const u8, size).to_vec();
+                sdl3::sys::stdinc::SDL_free(ptr);
+                ClipboardImage {
+                    mime_type: (*mime_type).to_owned(),
+                    data,
+                }
+            };
+            return Some(image);
+        }
+        None
+    })
+}
+
+pub(super) fn clipboard_image_from_path_text(text: &str) -> Option<ClipboardImage> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() || trimmed.contains('\n') {
+        return None;
+    }
+    let path = Path::new(trimmed);
+    if !path.is_file() {
+        return None;
+    }
+    let mime_type = match path
+        .extension()
+        .and_then(|extension| extension.to_str())?
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        _ => return None,
+    };
+    let data = std::fs::read(path).ok()?;
+    if data.is_empty() {
+        return None;
+    }
+    Some(ClipboardImage {
+        mime_type: mime_type.to_owned(),
+        data,
+    })
+}
+
 pub(super) fn yank_to_clipboard_text(yank: &YankRegister) -> Cow<'_, str> {
     match yank {
         YankRegister::Character(text) => Cow::Borrowed(text),
@@ -80,5 +150,26 @@ pub(super) fn yank_from_clipboard_text(text: &str) -> Option<YankRegister> {
         Some(YankRegister::Line(text.to_owned()))
     } else {
         Some(YankRegister::Character(text.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clipboard_image_from_path_text_reads_supported_image_files() {
+        let root = std::env::temp_dir().join(format!("volt-clipboard-image-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp dir");
+        let path = root.join("shot.png");
+        std::fs::write(&path, b"\x89PNG\r\n").expect("write png");
+
+        let image = clipboard_image_from_path_text(path.display().to_string().as_str())
+            .expect("clipboard image");
+        assert_eq!(image.mime_type, "image/png");
+        assert_eq!(image.data, b"\x89PNG\r\n");
+
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/editor-sdl/src/shell/mod.rs
+++ b/crates/editor-sdl/src/shell/mod.rs
@@ -372,7 +372,8 @@ const HOOK_LSP_CODE_ACTIONS: &str = lsp_hooks::CODE_ACTIONS;
 const HOOK_LSP_COPILOT_SIGN_IN: &str = lsp_hooks::COPILOT_SIGN_IN;
 const HOOK_LSP_COPILOT_SIGN_OUT: &str = lsp_hooks::COPILOT_SIGN_OUT;
 const COPILOT_LANGUAGE_SERVER: &str = "copilot-language-server";
-const ACP_INPUT_PLACEHOLDER: &str = "Type / for commands. Press M-x and `acp.` for other commands";
+const ACP_INPUT_PLACEHOLDER: &str =
+    "Type / for commands, @ for files. Paste images with Ctrl+Shift+V.";
 const QUICKFIX_BUFFER_NAME: &str = "*quickfix*";
 const QUICKFIX_POPUP_TITLE: &str = "Quickfix";
 const GIT_STATUS_KIND: &str = buffer_kinds::GIT_STATUS;
@@ -3807,6 +3808,28 @@ struct PluginTextPaneState {
 }
 
 #[derive(Debug, Clone)]
+struct AcpPendingImage {
+    mime_type: String,
+    data_base64: String,
+}
+
+impl AcpPendingImage {
+    fn from_clipboard(image: ClipboardImage) -> Self {
+        Self {
+            mime_type: image.mime_type,
+            data_base64: base64::engine::general_purpose::STANDARD.encode(image.data),
+        }
+    }
+
+    fn to_content_block(&self) -> ContentBlock {
+        ContentBlock::Image(agent_client_protocol::ImageContent::new(
+            self.data_base64.clone(),
+            self.mime_type.clone(),
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
 struct AcpBufferState {
     session_title: Option<String>,
     active_pane: AcpPane,
@@ -3817,6 +3840,7 @@ struct AcpBufferState {
     output_pane: AcpPaneState,
     input: InputField,
     footer_pane: PluginTextPaneState,
+    pending_images: Vec<AcpPendingImage>,
 }
 
 #[derive(Debug, Clone)]
@@ -3831,6 +3855,7 @@ struct AcpPaneState {
 #[derive(Debug, Clone)]
 enum AcpOutputItem {
     UserPrompt(String),
+    UserMessage(Vec<ContentBlock>),
     AgentBlocks(Vec<ContentBlock>),
     ToolCall(ToolCall),
     SystemMessage(String),
@@ -4066,6 +4091,7 @@ impl AcpBufferState {
                 min_rows: Some(1),
                 ..PluginTextPaneState::default()
             },
+            pending_images: Vec::new(),
         }
     }
 }
@@ -5448,6 +5474,13 @@ impl ShellBuffer {
     }
 
     pub(crate) fn acp_push_user_prompt(&mut self, prompt: impl Into<String>) -> bool {
+        self.acp_push_user_message(vec![ContentBlock::from(prompt.into())])
+    }
+
+    pub(crate) fn acp_push_user_message(&mut self, blocks: Vec<ContentBlock>) -> bool {
+        if blocks.is_empty() {
+            return false;
+        }
         let follow_output = self
             .acp_state
             .as_ref()
@@ -5460,10 +5493,43 @@ impl ShellBuffer {
         if let Some(state) = self.acp_state.as_mut() {
             state
                 .output_items
-                .push(AcpOutputItem::UserPrompt(prompt.into()));
+                .push(AcpOutputItem::UserMessage(blocks));
         }
         self.acp_rebuild_output_view(follow_output);
         follow_output
+    }
+
+    fn acp_add_pending_image(&mut self, image: ClipboardImage) -> bool {
+        let Some(state) = self.acp_state.as_mut() else {
+            return false;
+        };
+        state.pending_images.push(AcpPendingImage::from_clipboard(image));
+        true
+    }
+
+    fn acp_pending_image_count(&self) -> usize {
+        self.acp_state
+            .as_ref()
+            .map(|state| state.pending_images.len())
+            .unwrap_or(0)
+    }
+
+    fn acp_take_pending_images(&mut self) -> Vec<AcpPendingImage> {
+        self.acp_state
+            .as_mut()
+            .map(|state| std::mem::take(&mut state.pending_images))
+            .unwrap_or_default()
+    }
+
+    fn acp_clear_pending_images(&mut self) -> bool {
+        let Some(state) = self.acp_state.as_mut() else {
+            return false;
+        };
+        if state.pending_images.is_empty() {
+            return false;
+        }
+        state.pending_images.clear();
+        true
     }
 
     pub(crate) fn acp_push_system_message(&mut self, message: impl Into<String>) -> bool {
@@ -5657,7 +5723,8 @@ impl ShellBuffer {
     fn clear_input(&mut self) -> bool {
         if let Some(input) = self.input_field_mut() {
             input.clear();
-            return true;
+            let cleared_images = self.acp_clear_pending_images();
+            return true || cleared_images;
         }
         false
     }
@@ -7674,6 +7741,28 @@ fn acp_build_output_lines(
                     bubble_group,
                 ));
             }
+            AcpOutputItem::UserMessage(blocks) => {
+                let mut user_lines = Vec::new();
+                for block in blocks {
+                    let prefix = vec![
+                        acp_icon_segment(
+                            editor_icons::symbols::cod::COD_PERSON,
+                            AcpColorRole::Accent,
+                        ),
+                        acp_text_segment(" ", AcpColorRole::Default),
+                    ];
+                    user_lines.extend(acp_render_content_block(
+                        block,
+                        prefix,
+                        AcpColorRole::Accent,
+                    ));
+                }
+                lines.extend(acp_mark_chat(
+                    user_lines,
+                    AcpChatAlign::End,
+                    bubble_group,
+                ));
+            }
             AcpOutputItem::SystemMessage(message) => {
                 let prefix = vec![
                     acp_icon_segment(editor_icons::symbols::cod::COD_INFO, AcpColorRole::Muted),
@@ -8425,6 +8514,10 @@ enum PickerAction {
         buffer_id: BufferId,
         command: String,
     },
+    AcpInsertFileReference {
+        buffer_id: BufferId,
+        path: String,
+    },
     AcpLoadSession {
         buffer_id: BufferId,
         session_id: String,
@@ -8457,7 +8550,30 @@ enum PickerAction {
 enum PickerKind {
     Generic,
     AcpSlash { buffer_id: BufferId },
+    AcpFile { buffer_id: BufferId },
     AcpPermission { request_id: u64 },
+}
+
+fn acp_input_picker_kind_for_buffer(
+    picker_kind: Option<PickerKind>,
+    buffer_id: BufferId,
+) -> Option<PickerKind> {
+    match picker_kind {
+        Some(PickerKind::AcpSlash {
+            buffer_id: picker_buffer_id,
+        }) if picker_buffer_id == buffer_id => picker_kind,
+        Some(PickerKind::AcpFile {
+            buffer_id: picker_buffer_id,
+        }) if picker_buffer_id == buffer_id => picker_kind,
+        _ => None,
+    }
+}
+
+fn acp_input_picker_controls_input(picker_kind: Option<PickerKind>) -> bool {
+    matches!(
+        picker_kind,
+        Some(PickerKind::AcpSlash { .. }) | Some(PickerKind::AcpFile { .. })
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -11546,11 +11662,11 @@ impl ShellState {
                     && active_buffer.has_input
                     && input_field_paste_shortcut_requested(keycode, keymod)
                 {
-                    if let Some(text) = read_system_clipboard() {
-                        paste_text_into_active_input_buffer(&mut self.runtime, &text)
-                            .map_err(ShellError::Runtime)?;
+                    if paste_into_active_input_buffer(&mut self.runtime)
+                        .map_err(ShellError::Runtime)?
+                    {
+                        return Ok(false);
                     }
-                    return Ok(false);
                 }
                 if keymod.intersects(ctrl_mod())
                     && keycode == Keycode::J
@@ -11590,13 +11706,13 @@ impl ShellState {
                     return Ok(true);
                 }
 
-                let acp_slash_picker_active = matches!(
+                let acp_input_picker_active = acp_input_picker_kind_for_buffer(
                     self.ui()?.picker_kind(),
-                    Some(PickerKind::AcpSlash { buffer_id })
-                        if buffer_id == active_buffer.buffer_id
-                );
+                    active_buffer.buffer_id,
+                )
+                .is_some();
                 if picker_visible
-                    && acp_slash_picker_active
+                    && acp_input_picker_active
                     && matches!(
                         keycode,
                         Keycode::Return | Keycode::KpEnter | Keycode::Return2
@@ -11608,7 +11724,7 @@ impl ShellState {
                     self.sync_active_buffer().map_err(ShellError::Runtime)?;
                     return Ok(false);
                 }
-                if picker_visible && !acp_slash_picker_active {
+                if picker_visible && !acp_input_picker_active {
                     if matches!(
                         keycode,
                         Keycode::Return | Keycode::KpEnter | Keycode::Return2
@@ -11628,11 +11744,11 @@ impl ShellState {
                     return Ok(false);
                 }
                 if picker_visible
-                    && acp_slash_picker_active
+                    && acp_input_picker_active
                     && matches!(keycode, Keycode::Backspace | Keycode::Delete)
                 {
                     self.ui_mut()?.close_picker();
-                } else if picker_visible && acp_slash_picker_active {
+                } else if picker_visible && acp_input_picker_active {
                     return Ok(false);
                 }
 
@@ -11820,6 +11936,11 @@ impl ShellState {
                                     active_buffer.buffer_id,
                                 )
                                 .map_err(ShellError::Runtime)?;
+                                acp::maybe_open_file_completion(
+                                    &mut self.runtime,
+                                    active_buffer.buffer_id,
+                                )
+                                .map_err(ShellError::Runtime)?;
                                 acp::refresh_acp_input_hint(
                                     &mut self.runtime,
                                     active_buffer.buffer_id,
@@ -11849,6 +11970,11 @@ impl ShellState {
                             }
                             if active_buffer.is_acp {
                                 acp::maybe_open_slash_completion(
+                                    &mut self.runtime,
+                                    active_buffer.buffer_id,
+                                )
+                                .map_err(ShellError::Runtime)?;
+                                acp::maybe_open_file_completion(
                                     &mut self.runtime,
                                     active_buffer.buffer_id,
                                 )
@@ -12987,9 +13113,8 @@ impl ShellState {
             }
             return Ok(());
         }
-        let acp_slash_picker_active =
-            matches!(self.ui()?.picker_kind(), Some(PickerKind::AcpSlash { .. }));
-        if self.picker_visible()? && !acp_slash_picker_active {
+        let acp_input_picker_active = acp_input_picker_controls_input(self.ui()?.picker_kind());
+        if self.picker_visible()? && !acp_input_picker_active {
             clear_key_sequence(&mut self.runtime).map_err(ShellError::Runtime)?;
             if let Some(picker) = self.ui_mut()?.picker_mut() {
                 picker.append_query(text);
@@ -12997,7 +13122,7 @@ impl ShellState {
             self.schedule_picker_search_refresh()?;
             return Ok(());
         }
-        if acp_slash_picker_active {
+        if acp_input_picker_active {
             self.ui_mut()?.close_picker();
         }
         let active_buffer =
@@ -13032,6 +13157,8 @@ impl ShellState {
                     };
                     if handled {
                         acp::maybe_open_slash_completion(&mut self.runtime, buffer_id)
+                            .map_err(ShellError::Runtime)?;
+                        acp::maybe_open_file_completion(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
                         acp::refresh_acp_input_hint(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
@@ -13108,6 +13235,8 @@ impl ShellState {
                     };
                     if handled {
                         acp::maybe_open_slash_completion(&mut self.runtime, buffer_id)
+                            .map_err(ShellError::Runtime)?;
+                        acp::maybe_open_file_completion(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
                         acp::refresh_acp_input_hint(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
@@ -18977,6 +19106,10 @@ fn register_shell_hooks(runtime: &mut EditorRuntime) -> Result<(), String> {
                     acp::acp_insert_slash_command(runtime, buffer_id, &command)?;
                     sync_active_buffer(runtime)?;
                 }
+                PickerAction::AcpInsertFileReference { buffer_id, path } => {
+                    acp::acp_insert_file_reference(runtime, buffer_id, &path)?;
+                    sync_active_buffer(runtime)?;
+                }
                 PickerAction::AcpLoadSession {
                     buffer_id,
                     session_id,
@@ -24579,6 +24712,30 @@ fn input_field_paste_shortcut_requested(keycode: Keycode, keymod: Mod) -> bool {
         && !keymod.intersects(alt_mod() | gui_mod())
 }
 
+fn paste_into_active_input_buffer(runtime: &mut EditorRuntime) -> Result<bool, String> {
+    let buffer_id = active_shell_buffer_id(runtime)?;
+    let is_acp = {
+        let buffer = shell_buffer(runtime, buffer_id)?;
+        buffer_is_acp(&buffer.kind)
+    };
+    if is_acp {
+        if let Some(image) = read_system_clipboard_image().or_else(|| {
+            read_system_clipboard().and_then(|text| clipboard_image_from_path_text(&text))
+        }) {
+            let buffer = shell_buffer_mut(runtime, buffer_id)?;
+            if buffer.acp_add_pending_image(image) {
+                shell_ui_mut(runtime)?.close_picker();
+                acp::refresh_acp_input_hint(runtime, buffer_id)?;
+                return Ok(true);
+            }
+        }
+    }
+    if let Some(text) = read_system_clipboard() {
+        return paste_text_into_active_input_buffer(runtime, &text);
+    }
+    Ok(false)
+}
+
 fn paste_text_into_active_input_buffer(
     runtime: &mut EditorRuntime,
     text: &str,
@@ -24588,14 +24745,9 @@ fn paste_text_into_active_input_buffer(
         let buffer = shell_buffer(runtime, buffer_id)?;
         buffer_is_acp(&buffer.kind)
     };
-    let close_acp_slash_picker_first = is_acp
-        && matches!(
-            shell_ui(runtime)?.picker_kind(),
-            Some(PickerKind::AcpSlash {
-                buffer_id: picker_buffer_id,
-            }) if picker_buffer_id == buffer_id
-        );
-    if close_acp_slash_picker_first {
+    let close_acp_input_picker_first = is_acp
+        && acp_input_picker_kind_for_buffer(shell_ui(runtime)?.picker_kind(), buffer_id).is_some();
+    if close_acp_input_picker_first {
         shell_ui_mut(runtime)?.close_picker();
     }
     let handled = {
@@ -24610,6 +24762,7 @@ fn paste_text_into_active_input_buffer(
     if handled && is_acp {
         shell_ui_mut(runtime)?.close_picker();
         acp::maybe_open_slash_completion(runtime, buffer_id)?;
+        acp::maybe_open_file_completion(runtime, buffer_id)?;
         acp::refresh_acp_input_hint(runtime, buffer_id)?;
     }
     Ok(handled)
@@ -26145,11 +26298,15 @@ fn submit_input_buffer(runtime: &mut EditorRuntime) -> Result<(), String> {
             buffer.display_name().to_owned(),
         )
     };
+    if buffer_is_acp(&kind) {
+        let pending_images = shell_buffer_mut(runtime, buffer_id)?.acp_take_pending_images();
+        if text.trim().is_empty() && pending_images.is_empty() {
+            return Ok(());
+        }
+        return acp::submit_acp_prompt(runtime, buffer_id, &prompt, &text, pending_images);
+    }
     if text.trim().is_empty() {
         return Ok(());
-    }
-    if buffer_is_acp(&kind) {
-        return acp::submit_acp_prompt(runtime, buffer_id, &prompt, &text);
     }
     if buffer_is_browser(&kind) {
         return browser::submit_browser_input(runtime);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the ACP buffer input with two context features modeled after Zed and the [Agent Client Protocol content spec](https://agentclientprotocol.com/protocol/v2/content):

### @ file picker
- Typing `@` in the ACP input opens a fuzzy picker of git-visible workspace files (`git ls-files --cached --others --exclude-standard`).
- Selecting a file inserts `@relative/path ` into the message.
- On submit, `@`-mentions are resolved to embedded `ContentBlock::Resource` blocks (text or blob) with `ResourceLink` fallback, sent alongside the text block in the ACP `PromptRequest`.

### Image paste
- `Ctrl+Shift+V` in the ACP input checks clipboard image MIME types first (`image/png`, `image/jpeg`, `image/webp`, `image/gif`) via SDL3 `SDL_GetClipboardData`.
- If no raw image is present, a single-line clipboard path to an image file is loaded instead (avoids pasting a filepath string alongside image data, per Zed's approach).
- Pasted images are held as pending attachments until submit, shown in the footer hint ("N images attached"), and sent as `ContentBlock::Image` with base64 payload per ACP.

## Testing

Added unit tests:
- `acp_file_completion_query_detects_trailing_at_mention_token`
- `parse_at_mentions_collects_unique_paths`
- `build_acp_prompt_blocks_embeds_text_files_and_images`
- `clipboard_image_from_path_text_reads_supported_image_files`

```
cargo test -p editor-sdl build_acp_prompt_blocks acp_file_completion_query parse_at_mentions clipboard_image_from_path
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebbf9761-95ab-4616-bf9f-0f0f8eca81fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebbf9761-95ab-4616-bf9f-0f0f8eca81fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

