### PR TITLE
ACP input: @ git file mentions and clipboard image paste

### DIFF
--- a/crates/editor-sdl/src/shell/acp.rs
+++ b/crates/editor-sdl/src/shell/acp.rs
@@ -11,21 +11,23 @@ use std::{
 use agent_client_protocol::{Agent, Client, ClientSideConnection};
 use agent_client_protocol::{
     AuthCapabilities, AvailableCommand, ClientCapabilities, ContentBlock, CreateTerminalRequest,
-    CreateTerminalResponse, Error, FileSystemCapabilities, Implementation, InitializeRequest,
-    KillTerminalRequest, KillTerminalResponse, ListSessionsRequest, LoadSessionRequest, Meta,
-    ModelId, ModelInfo, NewSessionRequest, PermissionOption, PermissionOptionId,
-    PermissionOptionKind, Plan, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
-    ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
-    SessionConfigId, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectOption, SessionConfigSelectOptions, SessionConfigValueId, SessionInfo,
-    SessionInfoUpdate, SessionMode, SessionModeId, SessionModeState, SessionModelState,
-    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
-    SetSessionModelRequest, StopReason, TerminalExitStatus, TerminalId, TerminalOutputRequest,
-    TerminalOutputResponse, ToolCall, ToolCallUpdate, WaitForTerminalExitRequest,
-    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
+    CreateTerminalResponse, Error, FileSystemCapabilities, ImageContent, Implementation,
+    InitializeRequest, KillTerminalRequest, KillTerminalResponse, ListSessionsRequest,
+    LoadSessionRequest, Meta, ModelId, ModelInfo, NewSessionRequest, PermissionOption,
+    PermissionOptionId, PermissionOptionKind, Plan, ProtocolVersion, ReadTextFileRequest,
+    ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, ResourceLink,
+    SelectedPermissionOutcome, SessionConfigId, SessionConfigKind, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOption, SessionConfigSelectOptions,
+    SessionConfigValueId, SessionInfo, SessionInfoUpdate, SessionMode, SessionModeId,
+    SessionModeState, SessionModelState, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, StopReason,
+    TerminalExitStatus, TerminalId, TerminalOutputRequest, TerminalOutputResponse, ToolCall,
+    ToolCallUpdate, WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
+    WriteTextFileResponse,
 };
 use async_trait::async_trait;
+use base64::Engine as _;
 use editor_jobs::{ProcessSupervisionMode, supervised_command_if_resolved};
 use editor_picker::PickerResultOrder;
 use editor_plugin_api::AcpClient as AcpClientConfig;
@@ -1041,6 +1043,12 @@ pub(super) fn submit_acp_prompt(
             .map_err(|_| "acp manager lock was poisoned".to_owned())?;
         manager.session_for_buffer(buffer_id)
     };
+    let workspace_root = active_workspace_root(runtime)?.or_else(|| git_root(runtime).ok());
+    let images = {
+        let buffer = shell_buffer(runtime, buffer_id)?;
+        buffer.acp_pasted_images().to_vec()
+    };
+    let blocks = compose_acp_prompt_blocks(text, workspace_root.as_deref(), &images);
     let Some(session_id) = session_id else {
         let follow = {
             let buffer = shell_buffer_mut(runtime, buffer_id)?;
@@ -1063,7 +1071,7 @@ pub(super) fn submit_acp_prompt(
     let mut manager = manager
         .lock()
         .map_err(|_| "acp manager lock was poisoned".to_owned())?;
-    manager.prompt(session_id, text.to_owned())
+    manager.prompt(session_id, blocks)
 }
 
 pub(super) fn acp_complete_slash(runtime: &mut EditorRuntime) -> Result<(), String> {
@@ -1074,6 +1082,16 @@ pub(super) fn acp_complete_slash(runtime: &mut EditorRuntime) -> Result<(), Stri
         BufferKind::Plugin(plugin_kind) if plugin_kind == ACP_BUFFER_KIND
     ) {
         return Ok(());
+    }
+    if let Some(mention) = buffer
+        .input_field()
+        .and_then(|input| acp_file_mention_at_cursor(input.text(), input.cursor_char()))
+    {
+        return open_file_mention_picker(
+            runtime,
+            buffer_id,
+            CompletionTrigger::Auto(mention.query),
+        );
     }
     let query = buffer.input_field().and_then(|input| {
         let text = input.text();
@@ -1087,11 +1105,11 @@ pub(super) fn acp_complete_slash(runtime: &mut EditorRuntime) -> Result<(), Stri
     open_slash_command_picker(runtime, buffer_id, trigger)
 }
 
-pub(super) fn maybe_open_slash_completion(
+pub(super) fn maybe_open_acp_input_completion(
     runtime: &mut EditorRuntime,
     buffer_id: BufferId,
 ) -> Result<(), String> {
-    let Some(text) = ({
+    let Some((text, cursor)) = ({
         let buffer = shell_buffer(runtime, buffer_id)?;
         if !matches!(
             &buffer.kind,
@@ -1099,35 +1117,49 @@ pub(super) fn maybe_open_slash_completion(
         ) {
             return Ok(());
         }
-        buffer.input_field().map(|input| input.text().to_owned())
+        buffer
+            .input_field()
+            .map(|input| (input.text().to_owned(), input.cursor_char()))
     }) else {
         return Ok(());
     };
     let picker_kind = shell_ui(runtime)?.picker_kind();
-    let slash_picker_active = matches!(
+    let inline_picker_active = matches!(
         picker_kind,
-        Some(PickerKind::AcpSlash {
-            buffer_id: picker_buffer_id,
-        }) if picker_buffer_id == buffer_id
+        Some(kind) if kind.acp_inline_buffer_id() == Some(buffer_id)
     );
-    let Some(trimmed) = acp_slash_completion_query(&text) else {
-        if slash_picker_active {
-            shell_ui_mut(runtime)?.close_picker();
+    if let Some(query) = acp_slash_completion_query(&text) {
+        if shell_ui(runtime)?.picker_visible() {
+            if inline_picker_active {
+                shell_ui_mut(runtime)?.close_picker();
+            } else {
+                return Ok(());
+            }
         }
-        return Ok(());
-    };
-    if shell_ui(runtime)?.picker_visible() {
-        if slash_picker_active {
-            shell_ui_mut(runtime)?.close_picker();
-        } else {
-            return Ok(());
-        }
+        return open_slash_command_picker(
+            runtime,
+            buffer_id,
+            CompletionTrigger::Auto(query.to_owned()),
+        );
     }
-    open_slash_command_picker(
-        runtime,
-        buffer_id,
-        CompletionTrigger::Auto(trimmed.to_owned()),
-    )
+    if let Some(mention) = acp_file_mention_at_cursor(&text, cursor) {
+        if shell_ui(runtime)?.picker_visible() {
+            if inline_picker_active {
+                shell_ui_mut(runtime)?.close_picker();
+            } else {
+                return Ok(());
+            }
+        }
+        return open_file_mention_picker(
+            runtime,
+            buffer_id,
+            CompletionTrigger::Auto(mention.query),
+        );
+    }
+    if inline_picker_active {
+        shell_ui_mut(runtime)?.close_picker();
+    }
+    Ok(())
 }
 
 pub(super) fn acp_insert_slash_command(
@@ -1152,6 +1184,75 @@ pub(super) fn acp_insert_slash_command(
     input.set_text(&next);
     refresh_acp_input_hint(runtime, buffer_id)?;
     Ok(())
+}
+
+pub(super) fn acp_insert_file_mention(
+    runtime: &mut EditorRuntime,
+    buffer_id: BufferId,
+    relative_path: &str,
+) -> Result<(), String> {
+    let buffer = shell_buffer_mut(runtime, buffer_id)?;
+    let Some(input) = buffer.input_field_mut() else {
+        return Err("ACP buffer has no input field".to_owned());
+    };
+    let text = input.text().to_owned();
+    let cursor = input.cursor_char();
+    let mention = acp_file_mention_at_cursor(&text, cursor).unwrap_or(FileMention {
+        at_char: cursor,
+        end_char: cursor,
+        query: String::new(),
+    });
+    let replacement = format!("@{relative_path} ");
+    input.replace_char_range(mention.at_char, mention.end_char, &replacement);
+    refresh_acp_input_hint(runtime, buffer_id)?;
+    Ok(())
+}
+
+pub(super) fn paste_image_into_active_input(
+    runtime: &mut EditorRuntime,
+    image: ClipboardImage,
+) -> Result<bool, String> {
+    let buffer_id = active_shell_buffer_id(runtime)?;
+    let is_acp = {
+        let buffer = shell_buffer(runtime, buffer_id)?;
+        buffer_is_acp(&buffer.kind)
+    };
+    if !is_acp {
+        return Ok(false);
+    }
+    close_acp_inline_picker_for(runtime, buffer_id, true)?;
+    let token = {
+        let buffer = shell_buffer_mut(runtime, buffer_id)?;
+        let Some(token) = buffer.acp_attach_pasted_image(image) else {
+            return Ok(false);
+        };
+        if let Some(input) = buffer.input_field_mut() {
+            if !input.text().is_empty()
+                && !input
+                    .text()
+                    .chars()
+                    .last()
+                    .is_some_and(|character| character.is_whitespace())
+            {
+                input.insert_text(" ");
+            }
+            input.insert_text(&token);
+            input.insert_text(" ");
+            true
+        } else {
+            false
+        }
+    };
+    if token {
+        shell_ui_mut(runtime)?.close_picker();
+        maybe_open_acp_input_completion(runtime, buffer_id)?;
+        refresh_acp_input_hint(runtime, buffer_id)?;
+    }
+    Ok(token)
+}
+
+pub(super) fn acp_image_mention_token(id: u64, name: &str) -> String {
+    format!("![{name}](acp-image:{id})")
 }
 
 fn format_acp_mode_label(mode_id: &SessionModeId) -> String {
@@ -1898,6 +1999,153 @@ fn acp_slash_completion_query(text: &str) -> Option<&str> {
     (!trimmed.chars().any(|character| character.is_whitespace())).then_some(trimmed)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileMention {
+    at_char: usize,
+    end_char: usize,
+    query: String,
+}
+
+fn acp_file_mention_at_cursor(text: &str, cursor: usize) -> Option<FileMention> {
+    let chars: Vec<char> = text.chars().collect();
+    let cursor = cursor.min(chars.len());
+    let mut start = cursor;
+    while start > 0 {
+        let previous = chars[start - 1];
+        if previous.is_whitespace() {
+            break;
+        }
+        start -= 1;
+    }
+    if start >= chars.len() || chars[start] != '@' {
+        return None;
+    }
+    if start > 0 && !chars[start - 1].is_whitespace() {
+        return None;
+    }
+    let mut end = start + 1;
+    while end < chars.len() && !chars[end].is_whitespace() {
+        end += 1;
+    }
+    if cursor < start || cursor > end {
+        return None;
+    }
+    let query_end = cursor.max(start + 1).min(end);
+    Some(FileMention {
+        at_char: start,
+        end_char: end,
+        query: chars[start + 1..query_end].iter().collect(),
+    })
+}
+
+fn acp_file_uri(path: &Path) -> String {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|| path.to_path_buf())
+    };
+    url::Url::from_file_path(&absolute)
+        .map(|url| url.to_string())
+        .unwrap_or_else(|_| format!("file://{}", absolute.display()))
+}
+
+fn compose_acp_prompt_blocks(
+    text: &str,
+    workspace_root: Option<&Path>,
+    images: &[AcpPastedImage],
+) -> Vec<ContentBlock> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut blocks = Vec::new();
+    let mut index = 0usize;
+    let mut text_start = 0usize;
+
+    fn flush_text(blocks: &mut Vec<ContentBlock>, chars: &[char], start: usize, end: usize) {
+        if start >= end {
+            return;
+        }
+        let text: String = chars[start..end].iter().collect();
+        if !text.is_empty() {
+            blocks.push(ContentBlock::Text(agent_client_protocol::TextContent::new(
+                text,
+            )));
+        }
+    }
+
+    while index < chars.len() {
+        if let Some((end, image)) = parse_acp_image_mention(&chars, index, images) {
+            flush_text(&mut blocks, &chars, text_start, index);
+            blocks.push(ContentBlock::Image(
+                ImageContent::new(image.data.clone(), image.mime_type.clone())
+                    .uri(format!("volt://agent/pasted-image?name={}", image.name)),
+            ));
+            index = end;
+            text_start = end;
+            continue;
+        }
+        if chars[index] == '@'
+            && (index == 0 || chars[index - 1].is_whitespace())
+            && let Some(mention) = acp_file_mention_at_cursor(text, index + 1)
+        {
+            let relative = chars[mention.at_char + 1..mention.end_char]
+                .iter()
+                .collect::<String>();
+            if !relative.is_empty() {
+                flush_text(&mut blocks, &chars, text_start, mention.at_char);
+                blocks.push(file_mention_content_block(workspace_root, &relative));
+                index = mention.end_char;
+                text_start = mention.end_char;
+                continue;
+            }
+        }
+        index += 1;
+    }
+    flush_text(&mut blocks, &chars, text_start, chars.len());
+    if blocks.is_empty() {
+        blocks.push(ContentBlock::from(text.to_owned()));
+    }
+    blocks
+}
+
+fn parse_acp_image_mention<'a>(
+    chars: &[char],
+    index: usize,
+    images: &'a [AcpPastedImage],
+) -> Option<(usize, &'a AcpPastedImage)> {
+    if index >= chars.len() || chars[index] != '!' {
+        return None;
+    }
+    let rest: String = chars[index..].iter().collect();
+    let rest = rest.strip_prefix("![")?;
+    let (name, rest) = rest.split_once("](acp-image:")?;
+    let (id_text, _rest) = rest.split_once(')')?;
+    let id = id_text.parse::<u64>().ok()?;
+    let image = images.iter().find(|image| image.id == id)?;
+    let consumed =
+        2 + name.chars().count() + "](acp-image:".chars().count() + id_text.chars().count() + 1;
+    Some((index + consumed, image))
+}
+
+fn file_mention_content_block(workspace_root: Option<&Path>, relative: &str) -> ContentBlock {
+    let path = workspace_root
+        .map(|root| root.join(relative))
+        .unwrap_or_else(|| PathBuf::from(relative));
+    if is_image_path(&path)
+        && let Some(image) = clipboard_image_from_path(&path)
+    {
+        return ContentBlock::Image(
+            ImageContent::new(
+                base64::engine::general_purpose::STANDARD.encode(image.bytes),
+                image.mime_type,
+            )
+            .uri(acp_file_uri(&path)),
+        );
+    }
+    ContentBlock::ResourceLink(ResourceLink::new(relative.to_owned(), acp_file_uri(&path)))
+}
+
 fn pending_slash_completion_trigger(
     buffer: &ShellBuffer,
     pending: PendingSlashTrigger,
@@ -1983,6 +2231,84 @@ fn open_slash_command_picker(
         CompletionTrigger::Manual => {}
     }
     shell_ui_mut(runtime)?.set_picker(picker.with_kind(PickerKind::AcpSlash { buffer_id }));
+    Ok(())
+}
+
+fn open_file_mention_picker(
+    runtime: &mut EditorRuntime,
+    buffer_id: BufferId,
+    trigger: CompletionTrigger,
+) -> Result<(), String> {
+    if shell_ui(runtime)?.picker_visible() {
+        return Ok(());
+    }
+    let root = git_root(runtime)
+        .ok()
+        .or_else(|| active_workspace_root(runtime).ok().flatten());
+    let Some(root) = root else {
+        let entries = vec![PickerEntry {
+            item: PickerItem::new(
+                "acp-files-no-root",
+                "Workspace has no project root",
+                "Open a project workspace before linking git files.",
+                None::<String>,
+            ),
+            action: PickerAction::NoOp,
+            quickfix: None,
+        }];
+        let picker = PickerOverlay::from_entries("ACP Files", entries);
+        shell_ui_mut(runtime)?.set_picker(picker.with_kind(PickerKind::AcpFile { buffer_id }));
+        return Ok(());
+    };
+    let entries = match list_repository_files(&root) {
+        Ok(files) if files.is_empty() => vec![PickerEntry {
+            item: PickerItem::new(
+                "acp-files-empty",
+                "No visible files found",
+                "Git did not report any tracked or unignored files.",
+                None::<String>,
+            ),
+            action: PickerAction::NoOp,
+            quickfix: None,
+        }],
+        Ok(files) => files
+            .into_iter()
+            .map(|relative_path| {
+                let absolute = root.join(&relative_path);
+                let label = relative_path.display().to_string();
+                PickerEntry {
+                    item: PickerItem::new(label.clone(), label.clone(), "", None::<String>)
+                        .with_search_text(label.clone())
+                        .with_fringe(editor_icons::seti_file_icon(&absolute)),
+                    action: PickerAction::AcpInsertFileMention {
+                        buffer_id,
+                        relative_path: label,
+                    },
+                    quickfix: None,
+                }
+            })
+            .collect(),
+        Err(error) => vec![PickerEntry {
+            item: PickerItem::new(
+                "acp-files-error",
+                "Unable to read git files",
+                error.to_string(),
+                None::<String>,
+            ),
+            action: PickerAction::NoOp,
+            quickfix: None,
+        }],
+    };
+    let mut picker = PickerOverlay::from_entries("ACP Files", entries);
+    match trigger {
+        CompletionTrigger::Auto(query) => {
+            if !query.is_empty() {
+                picker.append_query(&query);
+            }
+        }
+        CompletionTrigger::Manual => {}
+    }
+    shell_ui_mut(runtime)?.set_picker(picker.with_kind(PickerKind::AcpFile { buffer_id }));
     Ok(())
 }
 
@@ -2176,7 +2502,7 @@ impl AcpManager {
     fn prompt(
         &mut self,
         session_id: agent_client_protocol::SessionId,
-        prompt: String,
+        prompt: Vec<ContentBlock>,
     ) -> Result<(), String> {
         self.runtime.send(AcpCommand::Prompt { session_id, prompt })
     }
@@ -3355,7 +3681,7 @@ enum AcpCommand {
     },
     Prompt {
         session_id: agent_client_protocol::SessionId,
-        prompt: String,
+        prompt: Vec<ContentBlock>,
     },
     ListSessions {
         session_id: agent_client_protocol::SessionId,
@@ -3672,7 +3998,7 @@ async fn connect_acp_client(
 async fn send_acp_prompt(
     state: Rc<RefCell<AcpRuntimeState>>,
     session_id: agent_client_protocol::SessionId,
-    prompt: String,
+    prompt: Vec<ContentBlock>,
 ) -> Result<(), String> {
     let connection = {
         state
@@ -3682,10 +4008,7 @@ async fn send_acp_prompt(
             .map(|session| session.connection.clone())
     }
     .ok_or_else(|| "ACP session is not connected".to_owned())?;
-    let request = agent_client_protocol::PromptRequest::new(
-        session_id.clone(),
-        vec![ContentBlock::from(prompt)],
-    );
+    let request = agent_client_protocol::PromptRequest::new(session_id.clone(), prompt);
     let response = connection
         .prompt(request)
         .await
@@ -5452,5 +5775,71 @@ mod tests {
         assert!(acp_slash_completion_query("/fix\nmore").is_none());
         assert!(acp_slash_completion_query("i have this code //").is_none());
         assert!(acp_slash_completion_query(" //").is_none());
+    }
+
+    #[test]
+    fn acp_file_mention_at_cursor_requires_token_start() {
+        let mention = acp_file_mention_at_cursor("@", 1).expect("bare @");
+        assert_eq!(mention.at_char, 0);
+        assert_eq!(mention.end_char, 1);
+        assert_eq!(mention.query, "");
+
+        let mention = acp_file_mention_at_cursor("look at @src/main.rs", 20).expect("path");
+        assert_eq!(mention.query, "src/main.rs");
+        assert_eq!(mention.at_char, 8);
+
+        assert!(acp_file_mention_at_cursor("user@host.com", 13).is_none());
+        assert!(acp_file_mention_at_cursor("look at src", 11).is_none());
+    }
+
+    #[test]
+    fn compose_acp_prompt_blocks_splits_file_mentions_into_resource_links() {
+        let root = PathBuf::from("/workspace");
+        let blocks =
+            compose_acp_prompt_blocks("please review @src/main.rs thanks", Some(&root), &[]);
+        assert_eq!(blocks.len(), 3);
+        match &blocks[0] {
+            ContentBlock::Text(text) => assert_eq!(text.text, "please review "),
+            other => panic!("expected leading text, got {other:?}"),
+        }
+        match &blocks[1] {
+            ContentBlock::ResourceLink(link) => {
+                assert_eq!(link.name, "src/main.rs");
+                assert!(link.uri.ends_with("/src/main.rs") || link.uri.contains("src/main.rs"));
+                assert!(link.uri.starts_with("file:"));
+            }
+            other => panic!("expected resource link, got {other:?}"),
+        }
+        match &blocks[2] {
+            ContentBlock::Text(text) => assert_eq!(text.text, " thanks"),
+            other => panic!("expected trailing text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compose_acp_prompt_blocks_embeds_pasted_images() {
+        let images = vec![AcpPastedImage {
+            id: 1,
+            name: "Image".to_owned(),
+            mime_type: "image/png".to_owned(),
+            data: "abc123".to_owned(),
+        }];
+        let blocks = compose_acp_prompt_blocks("see ![Image](acp-image:1)", None, &images);
+        assert_eq!(blocks.len(), 2);
+        match &blocks[0] {
+            ContentBlock::Text(text) => assert_eq!(text.text, "see "),
+            other => panic!("expected leading text, got {other:?}"),
+        }
+        match &blocks[1] {
+            ContentBlock::Image(image) => {
+                assert_eq!(image.data, "abc123");
+                assert_eq!(image.mime_type, "image/png");
+                assert_eq!(
+                    image.uri.as_deref(),
+                    Some("volt://agent/pasted-image?name=Image")
+                );
+            }
+            other => panic!("expected image block, got {other:?}"),
+        }
     }
 }

--- a/crates/editor-sdl/src/shell/clipboard.rs
+++ b/crates/editor-sdl/src/shell/clipboard.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::cell::RefCell;
+use std::{cell::RefCell, ffi::CString, path::Path};
 
 struct ClipboardContext {
     video: sdl3::VideoSubsystem,
@@ -7,6 +7,30 @@ struct ClipboardContext {
 
 thread_local! {
     static CLIPBOARD_CONTEXT: RefCell<Option<ClipboardContext>> = const { RefCell::new(None) };
+}
+
+const CLIPBOARD_IMAGE_MIME_TYPES: &[&str] = &[
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/webp",
+    "image/gif",
+    "image/bmp",
+    "image/tiff",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ClipboardImage {
+    pub name: String,
+    pub mime_type: String,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ClipboardPaste {
+    Empty,
+    Text(String),
+    Image(ClipboardImage),
 }
 
 pub(super) fn register_clipboard_context(video: sdl3::VideoSubsystem) {
@@ -22,6 +46,10 @@ fn with_clipboard_util<T>(f: impl FnOnce(&sdl3::clipboard::ClipboardUtil) -> T) 
             f(&clipboard)
         })
     })
+}
+
+fn clipboard_video_ready() -> bool {
+    CLIPBOARD_CONTEXT.with(|context| context.borrow().is_some())
 }
 
 pub(super) fn configure_background_command(_command: &mut Command) {
@@ -53,6 +81,185 @@ pub(super) fn read_system_clipboard() -> Option<String> {
     .filter(|text| !text.is_empty())
 }
 
+pub(super) fn read_system_clipboard_paste() -> ClipboardPaste {
+    if let Some(image) = read_system_clipboard_image() {
+        return ClipboardPaste::Image(image);
+    }
+    match read_system_clipboard() {
+        Some(text) => {
+            if let Some(image) = clipboard_image_from_path_text(&text) {
+                ClipboardPaste::Image(image)
+            } else {
+                ClipboardPaste::Text(text)
+            }
+        }
+        None => ClipboardPaste::Empty,
+    }
+}
+
+fn read_system_clipboard_image() -> Option<ClipboardImage> {
+    if !clipboard_video_ready() {
+        return None;
+    }
+    for mime in CLIPBOARD_IMAGE_MIME_TYPES {
+        if let Some(bytes) = clipboard_data_for_mime(mime)
+            && let Some(image) = normalize_clipboard_image(bytes, Some(mime), "Image")
+        {
+            return Some(image);
+        }
+    }
+    if let Some(uris) = clipboard_text_for_mime("text/uri-list")
+        && let Some(image) = clipboard_image_from_uri_list(&uris)
+    {
+        return Some(image);
+    }
+    None
+}
+
+fn clipboard_data_for_mime(mime: &str) -> Option<Vec<u8>> {
+    let c_mime = CString::new(mime).ok()?;
+    unsafe {
+        if !sdl3::sys::clipboard::SDL_HasClipboardData(c_mime.as_ptr()) {
+            return None;
+        }
+        let mut size = 0usize;
+        let ptr = sdl3::sys::clipboard::SDL_GetClipboardData(c_mime.as_ptr(), &mut size);
+        if ptr.is_null() || size == 0 {
+            return None;
+        }
+        let bytes = std::slice::from_raw_parts(ptr.cast::<u8>(), size).to_vec();
+        sdl3::sys::stdinc::SDL_free(ptr);
+        Some(bytes)
+    }
+}
+
+fn clipboard_text_for_mime(mime: &str) -> Option<String> {
+    let bytes = clipboard_data_for_mime(mime)?;
+    let text = std::str::from_utf8(&bytes).ok()?.trim_end_matches('\0');
+    (!text.is_empty()).then(|| text.to_owned())
+}
+
+pub(super) fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("image/png")
+    } else if bytes.len() >= 3 && bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF {
+        Some("image/jpeg")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else if bytes.starts_with(b"BM") {
+        Some("image/bmp")
+    } else {
+        None
+    }
+}
+
+pub(super) fn is_image_path(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase())
+            .as_deref(),
+        Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tif" | "tiff")
+    )
+}
+
+pub(super) fn normalize_clipboard_image(
+    bytes: Vec<u8>,
+    claimed_mime: Option<&str>,
+    name: impl Into<String>,
+) -> Option<ClipboardImage> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let mime_type = sniff_image_mime(&bytes)
+        .or_else(|| claimed_mime.filter(|mime| mime.starts_with("image/") && *mime != "image/jpg"))
+        .map(str::to_owned)
+        .or_else(|| {
+            claimed_mime
+                .filter(|mime| *mime == "image/jpg")
+                .map(|_| "image/jpeg".to_owned())
+        });
+    let mime_type = match mime_type {
+        Some(mime) => mime,
+        None => {
+            image::load_from_memory(&bytes).ok()?;
+            "image/png".to_owned()
+        }
+    };
+    Some(ClipboardImage {
+        name: sanitize_image_name(name),
+        mime_type,
+        bytes,
+    })
+}
+
+pub(super) fn clipboard_image_from_path(path: &Path) -> Option<ClipboardImage> {
+    if !is_image_path(path) {
+        return None;
+    }
+    let bytes = fs::read(path).ok()?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("Image");
+    normalize_clipboard_image(bytes, None, name)
+}
+
+fn clipboard_image_from_path_text(text: &str) -> Option<ClipboardImage> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() || trimmed.contains('\n') {
+        return None;
+    }
+    let unquoted = trimmed
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_owned();
+    if let Some(path) = path_from_file_uri(&unquoted) {
+        return clipboard_image_from_path(&path);
+    }
+    let path = PathBuf::from(&unquoted);
+    if path.exists() {
+        clipboard_image_from_path(&path)
+    } else {
+        None
+    }
+}
+
+fn clipboard_image_from_uri_list(uris: &str) -> Option<ClipboardImage> {
+    for line in uris.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let path = path_from_file_uri(line).unwrap_or_else(|| PathBuf::from(line));
+        if let Some(image) = clipboard_image_from_path(&path) {
+            return Some(image);
+        }
+    }
+    None
+}
+
+fn path_from_file_uri(value: &str) -> Option<PathBuf> {
+    let url = url::Url::parse(value).ok()?;
+    if url.scheme() != "file" {
+        return None;
+    }
+    url.to_file_path().ok()
+}
+
+fn sanitize_image_name(name: impl Into<String>) -> String {
+    let name = name.into();
+    let sanitized = name.replace(['[', ']', '\n', '\r'], "");
+    if sanitized.trim().is_empty() {
+        "Image".to_owned()
+    } else {
+        sanitized
+    }
+}
+
 pub(super) fn yank_to_clipboard_text(yank: &YankRegister) -> Cow<'_, str> {
     match yank {
         YankRegister::Character(text) => Cow::Borrowed(text),
@@ -80,5 +287,57 @@ pub(super) fn yank_from_clipboard_text(text: &str) -> Option<YankRegister> {
         Some(YankRegister::Line(text.to_owned()))
     } else {
         Some(YankRegister::Character(text.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TINY_PNG: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    #[test]
+    fn sniff_image_mime_recognizes_png_magic() {
+        assert_eq!(sniff_image_mime(TINY_PNG), Some("image/png"));
+        assert_eq!(sniff_image_mime(b"not-an-image"), None);
+    }
+
+    #[test]
+    fn normalize_clipboard_image_prefers_sniffed_png_mime() {
+        let image = normalize_clipboard_image(TINY_PNG.to_vec(), Some("image/jpeg"), "shot")
+            .expect("png should normalize");
+        assert_eq!(image.mime_type, "image/png");
+        assert_eq!(image.name, "shot");
+        assert_eq!(image.bytes, TINY_PNG);
+    }
+
+    #[test]
+    fn clipboard_image_from_path_loads_named_png() {
+        let dir = std::env::temp_dir().join(format!(
+            "volt-clipboard-image-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("screenshot.png");
+        fs::write(&path, TINY_PNG).expect("write png");
+        let image = clipboard_image_from_path(&path).expect("load png");
+        assert_eq!(image.name, "screenshot.png");
+        assert_eq!(image.mime_type, "image/png");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn clipboard_image_from_path_text_ignores_plain_text() {
+        assert!(clipboard_image_from_path_text("hello world").is_none());
+        assert!(clipboard_image_from_path_text("not/a/real/image.png").is_none());
     }
 }

--- a/crates/editor-sdl/src/shell/mod.rs
+++ b/crates/editor-sdl/src/shell/mod.rs
@@ -372,7 +372,8 @@ const HOOK_LSP_CODE_ACTIONS: &str = lsp_hooks::CODE_ACTIONS;
 const HOOK_LSP_COPILOT_SIGN_IN: &str = lsp_hooks::COPILOT_SIGN_IN;
 const HOOK_LSP_COPILOT_SIGN_OUT: &str = lsp_hooks::COPILOT_SIGN_OUT;
 const COPILOT_LANGUAGE_SERVER: &str = "copilot-language-server";
-const ACP_INPUT_PLACEHOLDER: &str = "Type / for commands. Press M-x and `acp.` for other commands";
+const ACP_INPUT_PLACEHOLDER: &str =
+    "Type / for commands, @ for files. Paste images with Ctrl+Shift+V";
 const QUICKFIX_BUFFER_NAME: &str = "*quickfix*";
 const QUICKFIX_POPUP_TITLE: &str = "Quickfix";
 const GIT_STATUS_KIND: &str = buffer_kinds::GIT_STATUS;
@@ -3817,6 +3818,16 @@ struct AcpBufferState {
     output_pane: AcpPaneState,
     input: InputField,
     footer_pane: PluginTextPaneState,
+    pasted_images: Vec<AcpPastedImage>,
+    next_image_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AcpPastedImage {
+    id: u64,
+    name: String,
+    mime_type: String,
+    data: String,
 }
 
 #[derive(Debug, Clone)]
@@ -4066,6 +4077,8 @@ impl AcpBufferState {
                 min_rows: Some(1),
                 ..PluginTextPaneState::default()
             },
+            pasted_images: Vec::new(),
+            next_image_id: 1,
         }
     }
 }
@@ -5655,11 +5668,37 @@ impl ShellBuffer {
     }
 
     fn clear_input(&mut self) -> bool {
-        if let Some(input) = self.input_field_mut() {
+        let cleared = if let Some(input) = self.input_field_mut() {
             input.clear();
-            return true;
+            true
+        } else {
+            false
+        };
+        if cleared && let Some(state) = self.acp_state.as_mut() {
+            state.pasted_images.clear();
         }
-        false
+        cleared
+    }
+
+    fn acp_attach_pasted_image(&mut self, image: ClipboardImage) -> Option<String> {
+        let state = self.acp_state.as_mut()?;
+        let id = state.next_image_id;
+        state.next_image_id = state.next_image_id.saturating_add(1);
+        let token = acp::acp_image_mention_token(id, &image.name);
+        state.pasted_images.push(AcpPastedImage {
+            id,
+            name: image.name,
+            mime_type: image.mime_type,
+            data: base64::engine::general_purpose::STANDARD.encode(image.bytes),
+        });
+        Some(token)
+    }
+
+    fn acp_pasted_images(&self) -> &[AcpPastedImage] {
+        self.acp_state
+            .as_ref()
+            .map(|state| state.pasted_images.as_slice())
+            .unwrap_or(&[])
     }
 
     fn section_state(&self) -> Option<&SectionedBufferState> {
@@ -8425,6 +8464,10 @@ enum PickerAction {
         buffer_id: BufferId,
         command: String,
     },
+    AcpInsertFileMention {
+        buffer_id: BufferId,
+        relative_path: String,
+    },
     AcpLoadSession {
         buffer_id: BufferId,
         session_id: String,
@@ -8457,7 +8500,23 @@ enum PickerAction {
 enum PickerKind {
     Generic,
     AcpSlash { buffer_id: BufferId },
+    AcpFile { buffer_id: BufferId },
     AcpPermission { request_id: u64 },
+}
+
+impl PickerKind {
+    fn acp_inline_buffer_id(self) -> Option<BufferId> {
+        match self {
+            PickerKind::AcpSlash { buffer_id } | PickerKind::AcpFile { buffer_id } => {
+                Some(buffer_id)
+            }
+            PickerKind::Generic | PickerKind::AcpPermission { .. } => None,
+        }
+    }
+
+    fn is_acp_inline(self) -> bool {
+        self.acp_inline_buffer_id().is_some()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -11546,10 +11605,8 @@ impl ShellState {
                     && active_buffer.has_input
                     && input_field_paste_shortcut_requested(keycode, keymod)
                 {
-                    if let Some(text) = read_system_clipboard() {
-                        paste_text_into_active_input_buffer(&mut self.runtime, &text)
-                            .map_err(ShellError::Runtime)?;
-                    }
+                    paste_into_active_input_buffer(&mut self.runtime)
+                        .map_err(ShellError::Runtime)?;
                     return Ok(false);
                 }
                 if keymod.intersects(ctrl_mod())
@@ -11590,13 +11647,12 @@ impl ShellState {
                     return Ok(true);
                 }
 
-                let acp_slash_picker_active = matches!(
+                let acp_inline_picker_active = matches!(
                     self.ui()?.picker_kind(),
-                    Some(PickerKind::AcpSlash { buffer_id })
-                        if buffer_id == active_buffer.buffer_id
+                    Some(kind) if kind.acp_inline_buffer_id() == Some(active_buffer.buffer_id)
                 );
                 if picker_visible
-                    && acp_slash_picker_active
+                    && acp_inline_picker_active
                     && matches!(
                         keycode,
                         Keycode::Return | Keycode::KpEnter | Keycode::Return2
@@ -11608,7 +11664,7 @@ impl ShellState {
                     self.sync_active_buffer().map_err(ShellError::Runtime)?;
                     return Ok(false);
                 }
-                if picker_visible && !acp_slash_picker_active {
+                if picker_visible && !acp_inline_picker_active {
                     if matches!(
                         keycode,
                         Keycode::Return | Keycode::KpEnter | Keycode::Return2
@@ -11628,11 +11684,11 @@ impl ShellState {
                     return Ok(false);
                 }
                 if picker_visible
-                    && acp_slash_picker_active
+                    && acp_inline_picker_active
                     && matches!(keycode, Keycode::Backspace | Keycode::Delete)
                 {
                     self.ui_mut()?.close_picker();
-                } else if picker_visible && acp_slash_picker_active {
+                } else if picker_visible && acp_inline_picker_active {
                     return Ok(false);
                 }
 
@@ -11815,7 +11871,7 @@ impl ShellState {
                                 input.backspace();
                             }
                             if active_buffer.is_acp {
-                                acp::maybe_open_slash_completion(
+                                acp::maybe_open_acp_input_completion(
                                     &mut self.runtime,
                                     active_buffer.buffer_id,
                                 )
@@ -11848,7 +11904,7 @@ impl ShellState {
                                 input.delete_forward();
                             }
                             if active_buffer.is_acp {
-                                acp::maybe_open_slash_completion(
+                                acp::maybe_open_acp_input_completion(
                                     &mut self.runtime,
                                     active_buffer.buffer_id,
                                 )
@@ -12987,9 +13043,9 @@ impl ShellState {
             }
             return Ok(());
         }
-        let acp_slash_picker_active =
-            matches!(self.ui()?.picker_kind(), Some(PickerKind::AcpSlash { .. }));
-        if self.picker_visible()? && !acp_slash_picker_active {
+        let acp_inline_picker_active =
+            matches!(self.ui()?.picker_kind(), Some(kind) if kind.is_acp_inline());
+        if self.picker_visible()? && !acp_inline_picker_active {
             clear_key_sequence(&mut self.runtime).map_err(ShellError::Runtime)?;
             if let Some(picker) = self.ui_mut()?.picker_mut() {
                 picker.append_query(text);
@@ -12997,7 +13053,7 @@ impl ShellState {
             self.schedule_picker_search_refresh()?;
             return Ok(());
         }
-        if acp_slash_picker_active {
+        if acp_inline_picker_active {
             self.ui_mut()?.close_picker();
         }
         let active_buffer =
@@ -13031,7 +13087,7 @@ impl ShellState {
                         }
                     };
                     if handled {
-                        acp::maybe_open_slash_completion(&mut self.runtime, buffer_id)
+                        acp::maybe_open_acp_input_completion(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
                         acp::refresh_acp_input_hint(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
@@ -13107,7 +13163,7 @@ impl ShellState {
                         }
                     };
                     if handled {
-                        acp::maybe_open_slash_completion(&mut self.runtime, buffer_id)
+                        acp::maybe_open_acp_input_completion(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
                         acp::refresh_acp_input_hint(&mut self.runtime, buffer_id)
                             .map_err(ShellError::Runtime)?;
@@ -18977,6 +19033,13 @@ fn register_shell_hooks(runtime: &mut EditorRuntime) -> Result<(), String> {
                     acp::acp_insert_slash_command(runtime, buffer_id, &command)?;
                     sync_active_buffer(runtime)?;
                 }
+                PickerAction::AcpInsertFileMention {
+                    buffer_id,
+                    relative_path,
+                } => {
+                    acp::acp_insert_file_mention(runtime, buffer_id, &relative_path)?;
+                    sync_active_buffer(runtime)?;
+                }
                 PickerAction::AcpLoadSession {
                     buffer_id,
                     session_id,
@@ -24579,6 +24642,21 @@ fn input_field_paste_shortcut_requested(keycode: Keycode, keymod: Mod) -> bool {
         && !keymod.intersects(alt_mod() | gui_mod())
 }
 
+fn paste_into_active_input_buffer(runtime: &mut EditorRuntime) -> Result<bool, String> {
+    match read_system_clipboard_paste() {
+        ClipboardPaste::Empty => Ok(false),
+        ClipboardPaste::Text(text) => paste_text_into_active_input_buffer(runtime, &text),
+        ClipboardPaste::Image(image) => paste_image_into_active_input_buffer(runtime, image),
+    }
+}
+
+fn paste_image_into_active_input_buffer(
+    runtime: &mut EditorRuntime,
+    image: ClipboardImage,
+) -> Result<bool, String> {
+    acp::paste_image_into_active_input(runtime, image)
+}
+
 fn paste_text_into_active_input_buffer(
     runtime: &mut EditorRuntime,
     text: &str,
@@ -24588,16 +24666,7 @@ fn paste_text_into_active_input_buffer(
         let buffer = shell_buffer(runtime, buffer_id)?;
         buffer_is_acp(&buffer.kind)
     };
-    let close_acp_slash_picker_first = is_acp
-        && matches!(
-            shell_ui(runtime)?.picker_kind(),
-            Some(PickerKind::AcpSlash {
-                buffer_id: picker_buffer_id,
-            }) if picker_buffer_id == buffer_id
-        );
-    if close_acp_slash_picker_first {
-        shell_ui_mut(runtime)?.close_picker();
-    }
+    close_acp_inline_picker_for(runtime, buffer_id, is_acp)?;
     let handled = {
         let buffer = shell_buffer_mut(runtime, buffer_id)?;
         if let Some(input) = buffer.input_field_mut() {
@@ -24609,10 +24678,26 @@ fn paste_text_into_active_input_buffer(
     };
     if handled && is_acp {
         shell_ui_mut(runtime)?.close_picker();
-        acp::maybe_open_slash_completion(runtime, buffer_id)?;
+        acp::maybe_open_acp_input_completion(runtime, buffer_id)?;
         acp::refresh_acp_input_hint(runtime, buffer_id)?;
     }
     Ok(handled)
+}
+
+fn close_acp_inline_picker_for(
+    runtime: &mut EditorRuntime,
+    buffer_id: BufferId,
+    is_acp: bool,
+) -> Result<(), String> {
+    if is_acp
+        && matches!(
+            shell_ui(runtime)?.picker_kind(),
+            Some(kind) if kind.acp_inline_buffer_id() == Some(buffer_id)
+        )
+    {
+        shell_ui_mut(runtime)?.close_picker();
+    }
+    Ok(())
 }
 
 fn motion_is_inclusive(motion: ShellMotion) -> bool {
@@ -33724,7 +33809,7 @@ fn placeholder_lines(name: &str, kind: &BufferKind, user_library: &dyn UserLibra
                 format!("{name} is an ACP session buffer."),
                 "Use acp.pick-client to start an ACP agent.".to_owned(),
                 "Type into the prompt and press Ctrl+Enter to send.".to_owned(),
-                "Use / for slash commands, Ctrl+Space/Tab for completion, Shift+Tab to cycle modes, Ctrl+Tab to switch ACP panes, acp.pick-mode to choose a mode, acp.pick-model to choose a model, and Ctrl+j for a newline."
+                "Use / for slash commands, @ to link git files, Ctrl+Shift+V to paste images, Ctrl+Space/Tab for completion, Shift+Tab to cycle modes, Ctrl+Tab to switch ACP panes, acp.pick-mode to choose a mode, acp.pick-model to choose a model, and Ctrl+j for a newline."
                     .to_owned(),
             ],
             BufferKind::Plugin(plugin_kind) if plugin_kind == GIT_STATUS_KIND => Vec::new(),

--- a/crates/editor-sdl/src/shell/tests.rs
+++ b/crates/editor-sdl/src/shell/tests.rs
@@ -12075,6 +12075,134 @@ fn acp_paste_code_with_inline_double_slash_comments_closes_slash_picker() -> Res
 }
 
 #[test]
+fn acp_at_symbol_opens_git_file_picker_and_return_inserts_mention() -> Result<(), String> {
+    let mut state = state_with_user_library()?;
+    let root = init_git_repo("acp-files")?;
+    fs::create_dir_all(root.join("src")).map_err(|error| error.to_string())?;
+    fs::write(root.join("src").join("main.rs"), "fn main() {}\n")
+        .map_err(|error| error.to_string())?;
+    run_git_in_dir(&root, &["add", "src/main.rs"])?;
+    open_workspace_from_project(&mut state.runtime, "acp-files", &root)
+        .map_err(|error| error.to_string())?;
+
+    let buffer_id = install_acp_test_buffer(&mut state, 0, "look at ", None)?;
+    {
+        let buffer = shell_buffer_mut(&mut state.runtime, buffer_id)?;
+        let _ = buffer.focus_acp_input();
+    }
+    {
+        let ui = shell_ui_mut(&mut state.runtime)?;
+        ui.set_active_vim_target(VimTarget::Input);
+        ui.enter_insert_mode();
+    }
+
+    state
+        .handle_text_input("@")
+        .map_err(|error| error.to_string())?;
+
+    {
+        let ui = shell_ui(&state.runtime)?;
+        let picker = ui
+            .picker()
+            .ok_or_else(|| "ACP file picker should open for @".to_owned())?;
+        assert_eq!(picker.session().title(), "ACP Files");
+        assert!(
+            picker
+                .session()
+                .matches()
+                .iter()
+                .any(|matched| matched.item().label() == "src/main.rs"),
+            "git file picker should list src/main.rs"
+        );
+        assert_eq!(ui.picker_kind(), Some(PickerKind::AcpFile { buffer_id }));
+    }
+
+    state
+        .handle_text_input("main.rs")
+        .map_err(|error| error.to_string())?;
+    let (render_width, render_height, cell_width, line_height) = markdown_table_event_dimensions();
+    state
+        .handle_event(
+            Event::KeyDown {
+                timestamp: 0,
+                window_id: 0,
+                keycode: Some(Keycode::Return),
+                scancode: None,
+                keymod: Mod::NOMOD,
+                repeat: false,
+                which: 0,
+                raw: 0,
+            },
+            render_width,
+            render_height,
+            cell_width,
+            line_height,
+        )
+        .map_err(|error| error.to_string())?;
+
+    let ui = shell_ui(&state.runtime)?;
+    assert!(!ui.picker_visible());
+    let buffer = ui
+        .buffer(buffer_id)
+        .ok_or_else(|| "ACP shell buffer missing".to_owned())?;
+    assert_eq!(
+        buffer
+            .input_field()
+            .ok_or_else(|| "ACP input field missing".to_owned())?
+            .text(),
+        "look at @src/main.rs "
+    );
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn acp_paste_image_inserts_mention_token_and_stores_bytes() -> Result<(), String> {
+    let mut state = ShellState::new().map_err(|error| error.to_string())?;
+    let buffer_id = install_acp_test_buffer(&mut state, 0, "see", None)?;
+    {
+        let buffer = shell_buffer_mut(&mut state.runtime, buffer_id)?;
+        let _ = buffer.focus_acp_input();
+    }
+    {
+        let ui = shell_ui_mut(&mut state.runtime)?;
+        ui.set_active_vim_target(VimTarget::Input);
+        ui.enter_insert_mode();
+    }
+
+    const TINY_PNG: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+    let image = normalize_clipboard_image(TINY_PNG.to_vec(), Some("image/png"), "Image")
+        .ok_or_else(|| "png should normalize".to_owned())?;
+    assert!(paste_image_into_active_input_buffer(
+        &mut state.runtime,
+        image
+    )?);
+
+    let buffer = shell_ui(&state.runtime)?
+        .buffer(buffer_id)
+        .ok_or_else(|| "ACP shell buffer missing".to_owned())?;
+    assert_eq!(
+        buffer
+            .input_field()
+            .ok_or_else(|| "ACP input field missing".to_owned())?
+            .text(),
+        "see ![Image](acp-image:1) "
+    );
+    let images = buffer.acp_pasted_images();
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].id, 1);
+    assert_eq!(images[0].mime_type, "image/png");
+    assert!(!images[0].data.is_empty());
+    Ok(())
+}
+
+#[test]
 fn paste_text_into_active_input_buffer_updates_browser_input() -> Result<(), String> {
     let mut state = ShellState::new().map_err(|error| error.to_string())?;
     let buffer_id = install_browser_test_buffer(&mut state)?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the ACP prompt input with two context attachments, composed into real ACP `ContentBlock`s on submit (not just extra text in the message).

### 1. `@` git file picker

Typing `@` in the ACP input opens a picker of git files (`git ls-files --cached --others --exclude-standard`), matching the workspace file picker. Return replaces the `@query` token with `@relative/path`.

On submit, each `@path` mention becomes:

- `ContentBlock::ResourceLink` with a `file://` URI (ACP baseline; every agent must support this)
- `ContentBlock::Image` when the mentioned file is itself an image, with base64 data + MIME type + file URI (same as Zed when attaching an image file)

Emails like `user@host.com` do not trigger the picker; `@` must start a token.

### 2. Clipboard image paste

`Ctrl+Shift+V` in the ACP input prefers image clipboard data over text, following Zed / ACP:

1. Read image MIME payloads via SDL3 (`image/png`, `image/jpeg`, `image/webp`, …)
2. Fall back to `text/uri-list` / a copied image file path (file-manager copy)
3. Sniff magic bytes for MIME, keep original bytes, base64-encode for ACP
4. Insert `![name](acp-image:N)` in the input and store the payload on the buffer

On submit that token becomes:

```json
{ "type": "image", "mimeType": "image/png", "data": "<base64>", "uri": "volt://agent/pasted-image?name=Image" }
```

This matches the ACP image content block and Zed’s pasted-image mention (`uri` + base64 + MIME), so vision-capable agents receive the pixels in-context rather than a path string.

Raw clipboard screenshots are labeled `Image`; copies of named files keep the filename.

## Test plan

- `cargo test -p editor-sdl --lib` for the new unit/integration tests:
  - `@` opens the git file picker and Return inserts `@src/main.rs`
  - pasted PNG becomes `![Image](acp-image:1)` plus stored base64
  - prompt composition splits text / ResourceLink / Image blocks
  - existing slash-command picker tests still pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60e449f9-9453-4693-99b6-c9c8261f948e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60e449f9-9453-4693-99b6-c9c8261f948e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

